### PR TITLE
enhance output to be a dict of various versioning information

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,9 @@
+version: 1
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "./"
+    update_schedule: "live"
+    default_reviewers:
+      - "tianhaoz95"
+    default_labels:
+      - "gem dependency update"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+name: release
 on:
   push:
     branches: 
@@ -10,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: setup ruby environment
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -23,4 +23,4 @@ jobs:
       - name: install dependencies
         run: bundle install
       - name: run tests
-        run: fastlane test
+        run: bundle exec fastlane test

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,0 +1,26 @@
+name: sentry
+on:
+  push:
+    branches: 
+      - "master"
+      - "dev/*"
+      - "fix/*"
+      - "refactor/*"
+      - "chore/*"
+  pull_request:
+    branches:
+      - "master"
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: setup ruby environment
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - name: install dependencies
+        run: bundle install
+      - name: run tests
+        run: fastlane test

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source("https://rubygems.org")
 
 gemspec
 
-gem "rufo"
+gem "rufo", "0.12.0"
 
-plugins_path = File.join(File.dirname(__FILE__), "fastlane", "Pluginfile")
-eval_gemfile(plugins_path) if File.exist?(plugins_path)
+eval_gemfile('fastlane/Pluginfile') if File.exist?('fastlane/Pluginfile')

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
-source('https://rubygems.org')
+source("https://rubygems.org")
 
 gemspec
 
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
+gem "rufo"
+
+plugins_path = File.join(File.dirname(__FILE__), "fastlane", "Pluginfile")
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"
 
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new
 
-require 'rubocop/rake_task'
+require "rubocop/rake_task"
 RuboCop::RakeTask.new(:rubocop)
 
 task(default: [:spec, :rubocop])

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,0 +1,98 @@
+name: photochatapp
+description: A mini donkey to help carry messages securely and secretly.
+
+# The following defines the version and build number for your application.
+# A version number is three numbers separated by dots, like 1.2.43
+# followed by an optional build number separated by a +.
+# Both the version and the builder number may be overridden in flutter
+# build by specifying --build-name and --build-number, respectively.
+# In Android, build-name is used as versionName while build-number used as versionCode.
+# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
+# In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
+# Read more about iOS versioning at
+# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
+version: 1.0.6+15
+
+environment:
+  sdk: ">=2.1.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+
+  # The following adds the Cupertino Icons font to your application.
+  # Use with the CupertinoIcons class for iOS style icons.
+  cupertino_icons: ^0.1.2
+  
+  # third party packages
+  image_picker: ^0.6.3+1
+  image_gallery_saver: ^1.2.2
+  esys_flutter_share: ^1.0.2
+  image: 
+  permission_handler: ^4.4.0+hotfix.2
+  encrypt: ^4.0.0
+  provider: ^4.0.4
+  http: ^0.12.0+4
+  intl: ^0.16.0
+  device_info: ^0.4.2+1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_driver:
+    sdk: flutter
+  test: any
+  mockito: ^4.1.1
+  path_provider: ^1.6.0
+  intl_translation: ^0.17.9
+
+# For information on the generic Dart part of this file, see the
+# following page: https://dart.dev/tools/pub/pubspec
+
+# The following section is specific to Flutter.
+flutter:
+  assets:
+    - "assets/photo_placeholder.png"
+    - "assets/loading_deer.gif"
+    - "assets/loading_donkey.gif"
+    - "assets/loading_husky.gif"
+    - "assets/message_logo.png"
+    - "assets/rabbits_clapping.gif"
+    - "assets/bear_bye.gif"
+    - "assets/in_love_corgi_long.gif"
+    - "assets/programming_corgi.gif"
+    - "assets/test_images/corgi.png"
+    - "assets/test_images/encrypted_corgi.png"
+
+  # The following line ensures that the Material Icons font is
+  # included with your application, so that you can use the icons in
+  # the material Icons class.
+  uses-material-design: true
+
+  # An image asset can refer to one or more resolution-specific "variants", see
+  # https://flutter.dev/assets-and-images/#resolution-aware.
+
+  # For details regarding adding assets from package dependencies, see
+  # https://flutter.dev/assets-and-images/#from-packages
+
+  # To add custom fonts to your application, add a fonts section here,
+  # in this "flutter" section. Each entry in this list should have a
+  # "family" key with the font family name, and a "fonts" key with a
+  # list giving the asset and other descriptors for the font. For
+  # example:
+  # fonts:
+  #   - family: Schyler
+  #     fonts:
+  #       - asset: fonts/Schyler-Regular.ttf
+  #       - asset: fonts/Schyler-Italic.ttf
+  #         style: italic
+  #   - family: Trajan Pro
+  #     fonts:
+  #       - asset: fonts/TrajanPro.ttf
+  #       - asset: fonts/TrajanPro_Bold.ttf
+  #         weight: 700
+  #
+  # For details regarding fonts from package dependencies,
+  # see https://flutter.dev/custom-fonts/#from-packages

--- a/fastlane-plugin-flutter_version.gemspec
+++ b/fastlane-plugin-flutter_version.gemspec
@@ -2,32 +2,32 @@
 
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'fastlane/plugin/flutter_version/version'
+require "fastlane/plugin/flutter_version/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'fastlane-plugin-flutter_version'
-  spec.version       = Fastlane::FlutterVersion::VERSION
-  spec.author        = 'tianhaoz95'
-  spec.email         = 'tianhaoz@umich.edu'
+  spec.name = "fastlane-plugin-flutter_version"
+  spec.version = Fastlane::FlutterVersion::VERSION
+  spec.author = "tianhaoz95"
+  spec.email = "tianhaoz@umich.edu"
 
-  spec.summary       = 'A plugin to retrieve versioning information for Flutter projects.'
-  spec.homepage      = "https://github.com/tianhaoz95/fastlane-plugin-flutter_version"
-  spec.license       = "MIT"
+  spec.summary = "A plugin to retrieve versioning information for Flutter projects."
+  spec.homepage = "https://github.com/tianhaoz95/fastlane-plugin-flutter_version"
+  spec.license = "MIT"
 
-  spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE)
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
+  spec.files = Dir["lib/**/*"] + %w(README.md LICENSE)
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
 
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency
 
-  spec.add_development_dependency('pry')
-  spec.add_development_dependency('bundler')
-  spec.add_development_dependency('rspec')
-  spec.add_development_dependency('rspec_junit_formatter')
-  spec.add_development_dependency('rake')
-  spec.add_development_dependency('rubocop', '0.49.1')
-  spec.add_development_dependency('rubocop-require_tools')
-  spec.add_development_dependency('simplecov')
-  spec.add_development_dependency('fastlane', '>= 2.142.0')
+  spec.add_development_dependency("pry")
+  spec.add_development_dependency("bundler")
+  spec.add_development_dependency("rspec")
+  spec.add_development_dependency("rspec_junit_formatter")
+  spec.add_development_dependency("rake")
+  spec.add_development_dependency("rubocop", "0.49.1")
+  spec.add_development_dependency("rubocop-require_tools")
+  spec.add_development_dependency("simplecov")
+  spec.add_development_dependency("fastlane", ">= 2.142.0")
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,28 @@
 lane :test do
-  flutter_version
+  version_info = flutter_version(
+    pubspec_location: "./example/pubspec.yaml",
+  )
+  puts version_info
+  # Tests if the version code retrieved from the pubspec.yaml matches
+  version_code = version_info["verison_code"]
+  correct_version_code = "15"
+  if version_code != correct_version_code
+    UI.user_error!(
+      "verison_code mismatched, expect "
+        .concat(correct_version_code)
+        .concat(", got ")
+        .concat(version_code)
+    )
+  end
+  # Tests if the verison name retrieved from the pubspec.yaml matches
+  version_name = version_info["version_name"]
+  expected_version_name = "1.0.6"
+  if version_name != expected_version_name
+    UI.user_error!(
+      "verison_name mismatched, expect "
+        .concat(expected_version_name)
+        .concat(", got ")
+        .concat(version_name)
+    )
+  end
 end

--- a/lib/fastlane/plugin/flutter_version.rb
+++ b/lib/fastlane/plugin/flutter_version.rb
@@ -1,10 +1,10 @@
-require 'fastlane/plugin/flutter_version/version'
+require "fastlane/plugin/flutter_version/version"
 
 module Fastlane
   module FlutterVersion
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
-      Dir[File.expand_path('**/{actions,helper}/*.rb', File.dirname(__FILE__))]
+      Dir[File.expand_path("**/{actions,helper}/*.rb", File.dirname(__FILE__))]
     end
   end
 end

--- a/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
+++ b/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
@@ -1,6 +1,6 @@
-require 'fastlane/action'
-require 'yaml'
-require_relative '../helper/flutter_version_helper'
+require "fastlane/action"
+require "yaml"
+require_relative "../helper/flutter_version_helper"
 
 module Fastlane
   module Actions
@@ -19,9 +19,10 @@ module Fastlane
         version_code = version_sections[1]
         UI.message("The version name: ".concat(version_name))
         UI.message("The version code: ".concat(version_code))
-        # The returned value should be a dictionary of all
-        # version informations instead of just a build number.
-        return version_code
+        return {
+                 "verison_code" => version_code,
+                 "version_name" => version_name,
+               }
       end
 
       def self.description
@@ -34,7 +35,7 @@ module Fastlane
 
       def self.return_value
         [
-          ['VERSION_CODE', 'The version code']
+          ["VERSION_CODE", "The version code"],
         ]
       end
 
@@ -50,7 +51,7 @@ module Fastlane
             description: "The location of pubspec.yml",
             optional: true,
             type: String,
-            default_value:"../pubspec.yaml"
+            default_value: "../pubspec.yaml",
           ),
         ]
       end

--- a/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
+++ b/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
@@ -19,6 +19,8 @@ module Fastlane
         version_code = version_sections[1]
         UI.message("The version name: ".concat(version_name))
         UI.message("The version code: ".concat(version_code))
+        # The returned value should be a dictionary of all
+        # version informations instead of just a build number.
         return version_code
       end
 

--- a/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
+++ b/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
@@ -6,7 +6,6 @@ module Fastlane
   module Actions
     class FlutterVersionAction < Action
       def self.run(params)
-        UI.message("The flutter_version plugin is working!")
         pubspec_location = params[:pubspec_location]
         pubspec = YAML.load_file(pubspec_location)
         version = pubspec["version"]

--- a/lib/fastlane/plugin/flutter_version/helper/flutter_version_helper.rb
+++ b/lib/fastlane/plugin/flutter_version/helper/flutter_version_helper.rb
@@ -1,4 +1,4 @@
-require 'fastlane_core/ui/ui'
+require "fastlane_core/ui/ui"
 
 module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?("UI")

--- a/spec/flutter_version_action_spec.rb
+++ b/spec/flutter_version_action_spec.rb
@@ -1,6 +1,6 @@
 describe Fastlane::Actions::FlutterVersionAction do
-  describe '#run' do
-    it 'prints a message' do
+  describe "#run" do
+    it "prints a message" do
       expect(Fastlane::UI).to receive(:message).with("The flutter_version plugin is working!")
 
       Fastlane::Actions::FlutterVersionAction.run(nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
-$LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
+$LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
 
-require 'simplecov'
+require "simplecov"
 
 # SimpleCov.minimum_coverage 95
 SimpleCov.start
@@ -9,7 +9,7 @@ SimpleCov.start
 module SpecHelper
 end
 
-require 'fastlane' # to import the Action super class
-require 'fastlane/plugin/flutter_version' # import the actual plugin
+require "fastlane" # to import the Action super class
+require "fastlane/plugin/flutter_version" # import the actual plugin
 
 Fastlane.load_actions # load other actions (in case your plugin calls other actions or shared values)


### PR DESCRIPTION
There are situations where version code is not the only thing needed. The output should be a dict with all the necessary information from `pubspec.yaml`.

Closes #4 