### PR TITLE
fix: remove dup code scanning deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source("https://rubygems.org")
 
 gem "rake"
-gem "code-scanning-rubocop", "0.3.0"
 gem 'codecov'
 
 gemspec


### PR DESCRIPTION
Somehow the code scanning dependency is duplicated? What? Well played GH?