### PR TITLE
fix: remove unless for multiline usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem "rufo", "0.12.0"
 
 eval_gemfile('fastlane/Pluginfile') if File.exist?('fastlane/Pluginfile')
 
-gem "code-scanning-rubocop", "= 0.3.0"
+gem "code-scanning-rubocop", "= 0.4.0"

--- a/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
+++ b/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
@@ -19,7 +19,7 @@ module Fastlane
         # rubocop:enable Style/RescueStandardError
         version = pubspec['version']
         UI.message('The full version is: '.dup.concat(version))
-        unless version.include?('+') raise 'Verson code indicator (+) not found in pubspec.yml'
+        raise 'Verson code indicator (+) not found in pubspec.yml' unless version.include?('+')
 
         version_sections = version.split('+')
         version_name = version_sections[0]

--- a/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
+++ b/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
@@ -19,9 +19,7 @@ module Fastlane
         # rubocop:enable Style/RescueStandardError
         version = pubspec['version']
         UI.message('The full version is: '.dup.concat(version))
-        if !version.include?('+')
-          raise 'Verson code indicator (+) not found in pubspec.yml'
-        end
+        unless version.include?('+') raise 'Verson code indicator (+) not found in pubspec.yml'
 
         version_sections = version.split('+')
         version_name = version_sections[0]

--- a/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
+++ b/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
@@ -19,7 +19,7 @@ module Fastlane
         # rubocop:enable Style/RescueStandardError
         version = pubspec['version']
         UI.message('The full version is: '.dup.concat(version))
-        if not version.include?('+')
+        if !version.include?('+')
           raise 'Verson code indicator (+) not found in pubspec.yml'
         end
 

--- a/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
+++ b/lib/fastlane/plugin/flutter_version/actions/flutter_version_action.rb
@@ -19,7 +19,7 @@ module Fastlane
         # rubocop:enable Style/RescueStandardError
         version = pubspec['version']
         UI.message('The full version is: '.dup.concat(version))
-        unless version.include?('+')
+        if not version.include?('+')
           raise 'Verson code indicator (+) not found in pubspec.yml'
         end
 


### PR DESCRIPTION
The linter 0.4.0 dislikes using unless for multiline so change it to be a plain if.