### PR TITLE
chore: deprecate the usage of rufo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ gem 'codecov'
 
 gemspec
 
-gem "rufo", "0.12.0"
-
 eval_gemfile('fastlane/Pluginfile') if File.exist?('fastlane/Pluginfile')
 
 gem "code-scanning-rubocop", "= 0.4.0"

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,5 @@
 require "bundler/gem_tasks"
 
-require "rspec/core/rake_task"
-RSpec::Core::RakeTask.new
-
 require "rubocop/rake_task"
 RuboCop::RakeTask.new(:rubocop)
 


### PR DESCRIPTION
Deprecate the usage of rufo package which was probably used for lint