### PR TITLE
fix: use native token for auth

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: hmarr/auto-approve-action@v2.1.0
         if: github.actor == 'dependabot[bot]' || github.actor == 'allcontributors[bot]'
         with:
-          github-token: "${{ secrets.USE_GITHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
As of now, the PR is not being blocked for any review reason, so using the GitHub action bot to do the approval is sufficient.